### PR TITLE
Standardize bot token

### DIFF
--- a/.github/workflows/cd.yml
+++ b/.github/workflows/cd.yml
@@ -21,7 +21,7 @@ jobs:
         run: yarn install
       - name: Build & Deploy Website
         env:
-          GIT_USER: ${{ secrets.DEPLOY_GH_PAGE_TOKEN }}
+          GIT_USER: ${{ secrets.BOT_TOKEN }}
         run: |
           git config --global user.name "dti-github-bot"
           git config --global user.email "admin@cornelldti.org"


### PR DESCRIPTION
### Summary

GitHub finally supports [org-wide secrets](https://github.blog/changelog/2020-05-14-organization-secrets/). It's time to migrate away repo-specific tokens, and use the org-wide token `BOT_TOKEN` and `FIREBASE_TOKEN` instead. It makes it much easier to routinely rotate the tokens for better security.

### Test Plan

Everything should still pass in CI.