### PR TITLE
Remove markdown lint from CI

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -7,14 +7,9 @@ jobs:
     steps:
       - uses: actions/checkout@v2
       - name: Set up Node
-        uses: actions/setup-node@v1
-      - uses: actions/setup-ruby@v1
-      - name: Setup Markdown Lint
-        run: gem install mdl
-      - name: Run Markdown Lint
-        run: mdl .
+        uses: actions/setup-node@v2-beta
       - name: Use Yarn Cache
-        uses: actions/cache@v1
+        uses: actions/cache@v2
         with:
           path: ~/.cache/yarn
           key: yarn-${{ hashFiles(format('{0}{1}', github.workspace, '/yarn.lock')) }}


### PR DESCRIPTION
Markdown lint is broken. See https://github.com/markdownlint/markdownlint/issues/341