### PR TITLE
Fix links with trailing slash

### DIFF
--- a/docs/assignments-common-requirements.md
+++ b/docs/assignments-common-requirements.md
@@ -7,14 +7,14 @@ title: 'Common Requirements'
 
 You will choose one of the below assignment options:
 
-- [Learning Goals + Learning Progress](./assignments-learning-doc) (**Newbie assignment only**)
-- [Pull Request Discussion](./assignments-pull-request-discussion)
-- [Unit Testing](./assignments-unit-testing)
-- [Documentation of Existing Code](./assignments-documentation)
-- [Semester Plan](./assignments-semester-plan) (**TPM first assignment only**, if you're a developer with a good reason for doing this, contact `@dev-leadz` )
-- [Semester Reflection](./assignments-semester-reflection) (** End of Semester assignment for full-credit developers and TPMs only **)
-- [Design Doc](./assignments-design-doc)
-- [Technical Critique/Security Vulnerability](./assignments-tech-critique-security-doc)
+- [Learning Goals + Learning Progress](/docs/assignments-learning-doc) (**Newbie assignment only**)
+- [Pull Request Discussion](/docs/assignments-pull-request-discussion)
+- [Unit Testing](/docs/assignments-unit-testing)
+- [Documentation of Existing Code](/docs/assignments-documentation)
+- [Semester Plan](/docs/assignments-semester-plan) (**TPM first assignment only**, if you're a developer with a good reason for doing this, contact `@dev-leadz` )
+- [Semester Reflection](/docs/assignments-semester-reflection) (** End of Semester assignment for full-credit developers and TPMs only **)
+- [Design Doc](/docs/assignments-design-doc)
+- [Technical Critique/Security Vulnerability](/docs/assignments-tech-critique-security-doc)
 
 _Have an idea for a different dev assignment option?_ Get permission from `@dev-leadz` and work with your TPM to ensure your idea is feasible and fits in our assignment requirements. Some example other dev assignment options we've accepted are: **dev onboarding document**, **TPM onboarding document**, and **SEV postmortem** (but do still let us know if you're considering these options!)
 

--- a/docs/assignments-design-doc.md
+++ b/docs/assignments-design-doc.md
@@ -37,4 +37,4 @@ overcommit or undercommit to any particular feature.
 
 ## Real Examples
 
-[CoursePlan Requirement Checking Design Document](./assignments-examples-cp-requirements-algo) by [Sam Zhou](https://developersam.com/)
+[CoursePlan Requirement Checking Design Document](/docs/assignments-examples-cp-requirements-algo) by [Sam Zhou](https://developersam.com/)

--- a/docs/getting-started-introduction.md
+++ b/docs/getting-started-introduction.md
@@ -8,6 +8,6 @@ This will serve as your go-to guide for how development functions on our team.
 
 Click one of the link below to start explore the website:
 
-- [I am a newbie](./onboarding-git)
-- [I want to learn the best practices](./guide-code-quality)
-- [I want to contribute to this website](./getting-started-contributing)
+- [I am a newbie](/docs/onboarding-git)
+- [I want to learn the best practices](/docs/guide-code-quality)
+- [I want to contribute to this website](/docs/getting-started-contributing)

--- a/docs/onboarding-dev-workflow.md
+++ b/docs/onboarding-dev-workflow.md
@@ -16,7 +16,7 @@ follow them for each of your task.
 
 ### Step 0: setup a local project
 
-See [Setup your project](./onboarding-git#setup-your-project) in the Git tutorial.
+See [Setup your project](/docs/onboarding-git#setup-your-project) in the Git tutorial.
 
 Skip if you alreday have your repository setup.
 
@@ -57,14 +57,14 @@ To ensure you do not exceed the limit, you need to plan before you write any cod
 
 You should keep your local repository to be up-to-date with latest `master`.
 
-See [Pull latest changes from remote](./onboarding-git#pull-latest-changes-from-remote) in the Git
+See [Pull latest changes from remote](/docs/onboarding-git#pull-latest-changes-from-remote) in the Git
 tutorial.
 
 ### Step 3: create a local branch
 
 Always start a new branch when you need to work on something new.
 
-See [Create a new branch](./onboarding-git#create-a-new-branch) in the Git tutorial.
+See [Create a new branch](/docs/onboarding-git#create-a-new-branch) in the Git tutorial.
 
 ### Step 4: make your changes
 
@@ -89,7 +89,7 @@ type errors. You should try to fix these errors instead of suppress them.
 
 ### Step 7: push your changes to remote
 
-See [Push to remote](./onboarding-git#push-to-remote) in the Git tutorial.
+See [Push to remote](/docs/onboarding-git#push-to-remote) in the Git tutorial.
 
 ### Step 8: create a pull request
 
@@ -147,5 +147,5 @@ Here are some example of bots participating in review:
 :tada: Your changes are merged. The continuous deployment scripts will automatically deploy your
 changes to staging.
 
-You should [delete your local branch](./onboarding-git#delete-a-branch) immediately, and start
+You should [delete your local branch](/docs/onboarding-git#delete-a-branch) immediately, and start
 your new work on a new branch.

--- a/docs/onboarding-editor.md
+++ b/docs/onboarding-editor.md
@@ -77,14 +77,14 @@ For more details check out the
 
 Documentation for XCode Setup is missing.
 
-Want to contribute? Check the [contributing guide](./getting-started-contributing.md).
+Want to contribute? Check the [contributing guide](/docs/getting-started-contributing.md).
 
 </TabItem>
 <TabItem value="android-studio">
 
 Documentation for Android Studio Setup is missing.
 
-Want to contribute? Check the [contributing guide](./getting-started-contributing.md).
+Want to contribute? Check the [contributing guide](/docs/getting-started-contributing.md).
 
 </TabItem>
 </Tabs>


### PR DESCRIPTION
Same issue was fixed by me in https://github.com/cornell-dti/trends-in-web-dev-website/pull/154

Netlify (I think) adds a trailing slash to the URL. This breaks local links, such as the ones in the assignment page.

Note that when you navigate to a page through the sidebar, the trailing slash gets removed and all the local links work fine again.

Anyways, if you specify `/docs/page` rather than `./page`, you avoid this issue anymore.